### PR TITLE
Add sample database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,27 @@
+# SQLite version 3.x
+#   gem install sqlite3
+#
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
+development:
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: sqlite3
+  database: db/test.sqlite3
+  pool: 5
+  timeout: 5000
+
+production:
+    adapter:
+    encoding: utf8
+    database:
+    username:
+    password:
+    host: localhost


### PR DESCRIPTION
We need to have a sample database.yml file so that Ruby doesn't complain that there are no database details to use.
