### PR TITLE
Render Google Analytics snippet in footer

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,13 +9,6 @@ html lang="en-US"
     link href="#{rss_path}" rel="alternate" title="RSS" type="application/rss+xml"
     link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,900' rel='stylesheet' type='text/css'
     = javascript_include_tag 'application'
-    - if INFO['ga_id']
-      /! Google Analytics
-      javascript:
-        var _gaq=[['_setAccount',' #{INFO['ga_id']} '],['_trackPageview']];
-        (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-        g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-        s.parentNode.insertBefore(g,s)}(document,'script'));
     = render partial: 'application/typekit'
   body class="#{controller_name} #{action_name} #{logged_in? ? '' : 'not-'}logged-in #{no_users? ? 'no-users' : ''}"
     #sheet
@@ -54,3 +47,10 @@ html lang="en-US"
           = render 'users/new_form'
         - else
           = render 'sessions/new_form'
+    / Google Analytics
+    - if INFO['ga_id']
+      javascript:
+        var _gaq=[['_setAccount',' #{INFO['ga_id']} '],['_trackPageview']];
+        (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+        g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g,s)}(document,'script'));


### PR DESCRIPTION
Render Google Analytics tracking code in footer before the closing body tag, as suggested by Google:

> This tracking code snippet should be included in your site's pages so that it appears at the bottom of the page's HTML (or generated-HTML) structure, before the closing `<body>` tag.

From: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingOverview
