### PR TITLE
Fix first user creation modal

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,7 +38,11 @@ class PostsController < ApplicationController
       @published = Post.where(draft:false).order('published_at desc')
       @drafts = Post.where(draft:true).order('updated_at desc')
     else
-      render 'sessions/new'
+      if no_users?
+        render 'users/create'
+      else
+        render 'sessions/new'
+      end
     end
   end
 


### PR DESCRIPTION
Current Situation:
When I spin up a brand new app (no users created yet) it sends me to a login page and asks for a username and password. That's confusing, because I don't have a user created yet.

Desired Situation:
App should check to see if there are users in the database when I go to /admin. If there are no users created yet, it should prompt me to create the first user. 
