### PR TITLE
Fixing the RSS feed so that it passes validation

### DIFF
--- a/app/views/posts/index.rss.builder
+++ b/app/views/posts/index.rss.builder
@@ -3,7 +3,7 @@ xml.rss :version => "2.0" do
   xml.channel do
     xml.title INFO['title']
     xml.description INFO['tagline']
-    xml.link root_path
+    xml.link INFO['domain'] + root_path
 
     for post in @posts
       xml.item do
@@ -13,7 +13,7 @@ xml.rss :version => "2.0" do
         else
           xml.description "No content"
         end
-        xml.pubDate post.created_at.to_formatted_s(:day_month_year)
+        xml.pubDate post.created_at.to_s(:rfc822)
         xml.link post_url(post)
         xml.guid post_url(post)
       end

--- a/config/info.yml
+++ b/config/info.yml
@@ -1,5 +1,7 @@
 <% def env(a, b); e = ENV["obtvse_#{a}"]; e ? e : b; end %>
 
+title: <%= env :title,     'Blog Title' %>
+domain: <%= env :domain,   'http://www.example.com' %>
 name:    <%= env :name,    'Full Name' %>
 twitter: <%= env :twitter, 'handle' %>
 github:  <%= env :github,  'username'  %>


### PR DESCRIPTION
Current Functionality:
The RSS feed does not validate. Some blog aggregators, such as Alltop.com, reject sites that don't pass RSS feed validation.

Testing:
You can test the validation of an RSS feed here: http://validator.w3.org/feed/

Example:
Nate's site doesn't validate.

Source: http://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fnatewienert.com%2Fposts.rss

Desired functionality:
RSS feed should pass the RSS feed validator.

Example:
My site, which has this fix, does validate: http://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fwww.lauradhamilton.com%2Fposts.rss
